### PR TITLE
allow custom validation messages without pattern

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,7 @@
                     /* falls through */
                 case "checkbox":
                     if (required && !this.get("checked")) {
-                        errors.push("field is required");
+                        errors.push(this.get("title") || "field is required");
                     }
                     break;
 
@@ -116,13 +116,13 @@
                             msg = this.get("title") || "illegal value format";
                         } else {
                             regexp = patterns[type];
-                            msg = I18N_MISMATCH[type];
+                            msg = this.get("title") || I18N_MISMATCH[type];
                         }
                     }
 
                     if (required && !regexp) {
                         regexp = patterns.required;
-                        msg = "field is required";
+                        msg = this.get("title") || "field is required";
                     }
 
                     if (regexp && !regexp.test(value)) {

--- a/test/forms.spec.js
+++ b/test/forms.spec.js
@@ -88,6 +88,17 @@ describe("forms", function() {
         expect(spy).toHaveBeenCalled();
     });*/
 
+
+    it("should allow custom tooltip messages via the title attribute", function() {
+        var ValiditySpy = spyOn(window, 'Validity');
+        var form = DOM.mock("form>input[type=text name=d title=customerror");
+        DOM.find("body").append(form);
+
+        expect(form).toBeValid();
+
+        expect(ValiditySpy).toHaveBeenCalledWith(["customerror"]);
+    });
+
     it("should allow to add custom validation", function() {
         var form = DOM.mock("form>input[type=text name=d]");
 


### PR DESCRIPTION
- I wanted to be able to allow custom validation messages but not have
to rely on client-side i18n and the use of the `pattern` attribute; this
commit allows that

- I’ve got a failing test here because I’m not super familiar with how
your testing setup is expected to work, I was hoping to be able to
verify the arguments of the Validity constructor, but it's private. I'm including the test in the hopes it reveals enough intent that you can help me out a bit with how to get this working :)